### PR TITLE
Correct J. Łukasiewicz spelling

### DIFF
--- a/Chapter-02/02-Programming-in-FORTH.tex
+++ b/Chapter-02/02-Programming-in-FORTH.tex
@@ -181,7 +181,7 @@ What would you expect the response \textbf{xxx} to be?
 \section{Stacks and reverse Polish notation (RPN)}
 \TallC{We} now discuss the stack and the "reverse Polish" or "postfix" arithmetic based on it. (Anyone who has used one of the Hewlett-Packard calculators should already be familiar with the basic concepts.)
 
-A Polish mathematician (J .Lukasewcleia) showed that numerical calculations require an irreducible minimum of elementary operations (fetching and storing numbers as well as addition, subtraction, multiplication and division). The minimum is obtained when the calculation is organized by "stack" arithmetic.
+A Polish mathematician (J. {\L}ukasiewicz) showed that numerical calculations require an irreducible minimum of elementary operations (fetching and storing numbers as well as addition, subtraction, multiplication and division). The minimum is obtained when the calculation is organized by "stack" arithmetic.
 
 Thus virtually all central processors (CPU's) intended for arithmetic operations are designed around stacks. FORTH makes efficient use of CPU's by reflecting this underlying stack architecture in its syntax, rather than translating algebraic-looking program statements ("infix" notation) into RPN-based machine operations as FORTRAN, BASIC, C and Pascal do.
 


### PR DESCRIPTION
Currently reads "Lukasewcleia". The original contains "Lukasewcleicz".
The correct form looks different still:

https://en.wikipedia.org/wiki/Jan_%C5%81ukasiewicz

addresses issue #18

I'm not sure how this sort of thing is intended to be treated, as it is incorrect in the original. Since there is an issue open I figured it was worth a change request to at least discuss whether or not it should be changed to the correct form (this patch).